### PR TITLE
adding the redos for invalid results

### DIFF
--- a/src/llmjptoen.py
+++ b/src/llmjptoen.py
@@ -163,19 +163,6 @@ def explain_word_in_line(input_data) -> list[list[Any]]:
 
     results = []
 
-    def is_japanese(input_data) -> bool:
-        for data in input_data:
-            jp_letter_counter = 0
-            len_data = len(data)
-            for letter in data:
-                if re.match(r'[\u3040-\u30FF\u4E00-\u9FFF]', letter):
-                    jp_letter_counter += 1
-
-            if jp_letter_counter / len_data > 0.4:
-                return True
-
-        return False
-
     for result, prompt_input in zip(output, prompt_list):
         input_word = prompt_input[1]
 
@@ -184,9 +171,9 @@ def explain_word_in_line(input_data) -> list[list[Any]]:
 
         if holding == [True, True, True, True, True]:
             globalfuncs.logger.notice(f"LLM Failure, passing and setting temporary value for {input_word} | Error: list index out of range")
-
-        if is_japanese(results[-1]):
-            globalfuncs.logger.notice(f"LLM Failure, passing and setting temporary value for {input_word} | Error: token is japanese")
+        else:
+            if globalfuncs.is_japanese(results[-1]):
+                globalfuncs.logger.notice(f"LLM Failure, passing and setting temporary value for {input_word} | Error: token is japanese")
 
     del prompt_list
     del output

--- a/src/main.py
+++ b/src/main.py
@@ -468,8 +468,6 @@ def main(url: str, use_genius: str, skip_dict_lookup=False, skip_llm_exp=False, 
                     continue
 
                 if s_meaning == [] or s_pos == [] or line_counter in missing_lines:
-                    # llm_result.append(None)
-                    # globalfuncs.write_json(None, filepath_json, ['llm', 'explanation', 'tokens'])
                     prompt_batch.append(True)
                     exclude_list.append(check_counter)
                     check_counter += 1
@@ -495,6 +493,7 @@ def main(url: str, use_genius: str, skip_dict_lookup=False, skip_llm_exp=False, 
             for lyric in item:
                 inline_tagged_lyrics.append(lyric)
 
+        # delete all llm results that origin from english words as to not waste computing power
         holding = []
         for result, token in zip(llm_result, inline_tagged_lyrics):
             if not globalfuncs.is_japanese(token, 0.9):

--- a/src/main.py
+++ b/src/main.py
@@ -522,11 +522,11 @@ def main(url: str, use_genius: str, skip_dict_lookup=False, skip_llm_exp=False, 
             holding = []
             counter = 0
             for result in llm_result:
-                if globalfuncs.is_japanese(result) or result == [True, True, True, True, True]:
-                    holding.append(response[counter])
-                    counter += 1
-                else:
-                    holding.append(result)
+                    if (globalfuncs.is_japanese(result) or result == [True, True, True, True, True]) and counter < len(response):
+                        holding.append(response[counter])
+                        counter += 1
+                    else:
+                        holding.append(result)
             llm_result = holding
             globalfuncs.write_json(llm_result, filepath_json, ['llm', 'explanation', 'tokens'], as_list=True,
                                    extend=False, overwrite=True)

--- a/src/main.py
+++ b/src/main.py
@@ -468,8 +468,6 @@ def main(url: str, use_genius: str, skip_dict_lookup=False, skip_llm_exp=False, 
                     continue
 
                 if s_meaning == [] or s_pos == [] or line_counter in missing_lines:
-                    # llm_result.append(None)
-                    # globalfuncs.write_json(None, filepath_json, ['llm', 'explanation', 'tokens'])
                     prompt_batch.append(True)
                     exclude_list.append(check_counter)
                     check_counter += 1
@@ -486,8 +484,6 @@ def main(url: str, use_genius: str, skip_dict_lookup=False, skip_llm_exp=False, 
         if prompt_batch:
             call_llm_and_save()
             prompt_batch = []
-
-        # TODO check after all prompts are made to redo the invalid ones
 
         inline_tagged_lyrics = []
         for item in dict_lookup_res:
@@ -633,3 +629,4 @@ if __name__ == '__main__':
     # main('https://www.youtube.com/watch?v=QnkqCv0dZTk', 'genius')
     main('youtube.com/watch?v=ZRtdQ81jPUQ', 'genius')
     # main('https://www.youtube.com/watch?v=Mhl9FaxiQ_E', 'genius')
+

--- a/src/main.py
+++ b/src/main.py
@@ -488,18 +488,87 @@ def main(url: str, use_genius: str, skip_dict_lookup=False, skip_llm_exp=False, 
             prompt_batch = []
 
         # TODO check after all prompts are made to redo the invalid ones
-        def is_japanese(input_data) -> bool:
-            for data in input_data:
-                jp_letter_counter = 0
-                len_data = len(data)
-                for letter in data:
-                    if re.match(r'[\u3040-\u30FF\u4E00-\u9FFF]', letter):
-                        jp_letter_counter += 1
 
-                if jp_letter_counter / len_data > 0.4:
-                    return True
+        inline_tagged_lyrics = []
+        for item in dict_lookup_res:
+            item = item[0]
+            for lyric in item:
+                inline_tagged_lyrics.append(lyric)
 
-            return False
+        holding = []
+        for result, token in zip(llm_result, inline_tagged_lyrics):
+            if not globalfuncs.is_japanese(token, 0.9):
+                holding.append([None])
+            else:
+                holding.append(result)
+        llm_result = holding
+        globalfuncs.write_json(llm_result, filepath_json, ['llm', 'explanation', 'tokens'], as_list=True, extend=False, overwrite=True)
+
+        def overwrite_call_llm_and_save():
+            nonlocal prompt_batch, attempt_try, llm_result
+
+            attempt_try = 1
+
+            while True:
+                try:
+                    response = llmjptoen.explain_word_in_line(prompt_batch)
+                    break
+                except Exception as e:
+                    attempt_try += 1
+                    globalfuncs.logger.notice(f"LLM Failure, trying again. Attempt: {attempt_try} | Error: {e}")
+                    torch.cuda.empty_cache()
+                    gc.collect()
+
+            holding = []
+            counter = 0
+            for result in llm_result:
+                if globalfuncs.is_japanese(result) or result == [True, True, True, True, True]:
+                    holding.append(response[counter])
+                    counter += 1
+                else:
+                    holding.append(result)
+            llm_result = holding
+            globalfuncs.write_json(llm_result, filepath_json, ['llm', 'explanation', 'tokens'], as_list=True,
+                                   extend=False, overwrite=True)
+
+        formatted_llm_result = []
+        list_index = 0
+        for lyric, tagged, dict in zip(jp_lyrics, tagged_lyrics, dict_lookup_res):
+            holding = []
+            for _ in range(len(dict[0])):
+                holding.append(llm_result[list_index])
+                list_index += 1
+
+            formatted_llm_result.append(holding)
+
+        break_off = False
+        while True:
+            prompt_batch = []
+            for lyric, lyric_line, result in zip(dict_lookup_res, jp_lyrics, formatted_llm_result):
+                token = lyric[0]
+                pos = lyric[1]
+                meaning = lyric[2]
+
+                for s_word, s_pos, s_meaning, s_result in zip(token, pos, meaning, result):
+                    if globalfuncs.is_japanese(s_result) or s_result == [True, True, True, True, True]:
+                        prompt_batch.append([lyric_line, s_word, s_pos, unsplit_jp_lyrics])
+
+                    if len(prompt_batch) >= llm_batch_size_explanation:
+                        print(prompt_batch)
+                        overwrite_call_llm_and_save()
+                        prompt_batch = []
+
+            if prompt_batch:
+                print(prompt_batch)
+                overwrite_call_llm_and_save()
+                prompt_batch = []
+
+            for meaning in llm_result:
+                if not globalfuncs.is_japanese(meaning) and meaning != [True, True, True, True, True]:
+                    break_off = True
+                    break
+            if break_off:
+                break
 
         llmjptoen.clear_model()
         globalfuncs.logger.info(f"Finished getting explanations of tokens")


### PR DESCRIPTION
# globalfuncs
- added overwrite feature for json write
- moved is_japanese to here so i dont DRY
# llmjptoen
- fixed logger bug
# main
- checking each result where they are japanese or the temporary value, then adding it to the prompt list then to be sent into the llm to be redone. no jp or invalid checks. output will be written and will loop over the results again until everything is finished. (assuming the information is correct until checked to save time since there are still valid responses in the failed batch)
- added function to delete english token results (since the llm bugs out with english inputs and its not useful lmao)